### PR TITLE
Remove compile flags for better compatibility.

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -19,7 +19,6 @@ ffi.set_source(
     ''',
     sources=sources,
     include_dirs=[include_dir],
-    extra_compile_args=['-std=c99', '-O3', '-march=native'],
 )
 with open(cdefs_file, 'r') as fp:
     ffi.cdef(fp.read())


### PR DESCRIPTION
The flags are not necessary, as the Python CFFI build includes optimisation flags automatically (although x86-64, not native), and GCC uses a more recent C11 standard by default. Not specifying flags avoids compiler warnings on Windows where the Visual Studio compiler doesn't support GCC flags.

If there are any performance drawbacks (e.g. not as good vectorization of ChaCha20 by the compiler), we can add platform detection and different flags for Windows.
