### PR TITLE
elligator2: expose low-level bindings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cffi>=1.14
-hypothesis==6.14.1
+hypothesis>=6.14.1
 pytest==6.2.4
 pytest-cov==2.12.1

--- a/src/monocypher/bindings/__init__.py
+++ b/src/monocypher/bindings/__init__.py
@@ -19,6 +19,10 @@ from .crypto_ed25519 import (
     crypto_ed25519_public_key, crypto_ed25519_sign, crypto_ed25519_check,
     crypto_from_ed25519_private, crypto_from_ed25519_public,
 )
+from .crypto_hidden import (
+    crypto_curve_to_hidden, crypto_hidden_to_curve,
+    crypto_hidden_key_pair,
+)
 
 __all__ = (
     'crypto_lock', 'crypto_unlock',

--- a/src/monocypher/bindings/crypto_hidden.py
+++ b/src/monocypher/bindings/crypto_hidden.py
@@ -1,39 +1,28 @@
 from monocypher.utils import ensure_length
-#from monocypher.public import PublicKey, PrivateKey
 from monocypher._monocypher import lib, ffi
 
-#int
-#crypto_curve_to_hidden(uint8_t hidden[32], const uint8_t curve[32], uint8_t tweak)
-#def curve_to_hidden(your_pk:PublicKey, tweak:bytes) -> Optional[bytes]:
-def crypto_curve_to_hidden(your_pk:bytes, tweak:int):
+def crypto_curve_to_hidden(your_pk, tweak):
     ensure_length('your_pk', your_pk, 32)
 
     curve = ffi.from_buffer('uint8_t[32]', your_pk)
     hidden = ffi.new('uint8_t[32]')
 
-    if 0 != lib.crypto_curve_to_hidden(hidden, curve, tweak):
+    if lib.crypto_curve_to_hidden(hidden, curve, tweak):
         return None # unsuitable for hiding
     return bytes(hidden)
 
 
-#void
-#crypto_hidden_to_curve(uint8_t curve[32], const uint8_t hidden[32]);
-#def hidden_to_curve(your_hidden_pk:bytes) -> PublicKey:
-def crypto_hidden_to_curve(your_hidden_pk:bytes) -> bytes:
+def crypto_hidden_to_curve(your_hidden_pk):
     ensure_length('your_hidden_pk', your_hidden_pk, 32)
 
     hidden = ffi.from_buffer('uint8_t[32]', your_hidden_pk)
     pk = ffi.new('uint8_t[32]')
 
     lib.crypto_hidden_to_curve(pk, hidden)
-#    return PublicKey(bytes(pk))
     return bytes(pk)
 
 
-#void
-#crypto_hidden_key_pair(uint8_t hidden[32], uint8_t secret_key[32], uint8_t seed[32]);
-#def hidden_key_pair(your_secret_seed:bytes) -> Tuple[bytes, PrivateKey]:
-def crypto_hidden_key_pair(your_secret_seed:bytes):
+def crypto_hidden_key_pair(your_secret_seed):
     ensure_length('your_secret_seed', your_secret_seed, 32)
 
     seed = ffi.from_buffer('uint8_t[32]', your_secret_seed)
@@ -41,5 +30,4 @@ def crypto_hidden_key_pair(your_secret_seed:bytes):
     hidden_pk = ffi.new('uint8_t[32]')
 
     lib.crypto_hidden_key_pair(hidden_pk, sk, seed)
-#    return bytes(hidden_pk), PrivateKey(bytes(sk))
     return bytes(hidden_pk), bytes(sk)

--- a/src/monocypher/bindings/crypto_hidden.py
+++ b/src/monocypher/bindings/crypto_hidden.py
@@ -1,0 +1,45 @@
+from monocypher.utils import ensure_length
+#from monocypher.public import PublicKey, PrivateKey
+from monocypher._monocypher import lib, ffi
+
+#int
+#crypto_curve_to_hidden(uint8_t hidden[32], const uint8_t curve[32], uint8_t tweak)
+#def curve_to_hidden(your_pk:PublicKey, tweak:bytes) -> Optional[bytes]:
+def crypto_curve_to_hidden(your_pk:bytes, tweak:int):
+    ensure_length('your_pk', your_pk, 32)
+
+    curve = ffi.from_buffer('uint8_t[32]', your_pk)
+    hidden = ffi.new('uint8_t[32]')
+
+    if 0 != lib.crypto_curve_to_hidden(hidden, curve, tweak):
+        return None # unsuitable for hiding
+    return bytes(hidden)
+
+
+#void
+#crypto_hidden_to_curve(uint8_t curve[32], const uint8_t hidden[32]);
+#def hidden_to_curve(your_hidden_pk:bytes) -> PublicKey:
+def crypto_hidden_to_curve(your_hidden_pk:bytes) -> bytes:
+    ensure_length('your_hidden_pk', your_hidden_pk, 32)
+
+    hidden = ffi.from_buffer('uint8_t[32]', your_hidden_pk)
+    pk = ffi.new('uint8_t[32]')
+
+    lib.crypto_hidden_to_curve(pk, hidden)
+#    return PublicKey(bytes(pk))
+    return bytes(pk)
+
+
+#void
+#crypto_hidden_key_pair(uint8_t hidden[32], uint8_t secret_key[32], uint8_t seed[32]);
+#def hidden_key_pair(your_secret_seed:bytes) -> Tuple[bytes, PrivateKey]:
+def crypto_hidden_key_pair(your_secret_seed:bytes):
+    ensure_length('your_secret_seed', your_secret_seed, 32)
+
+    seed = ffi.from_buffer('uint8_t[32]', your_secret_seed)
+    sk = ffi.new('uint8_t[32]')
+    hidden_pk = ffi.new('uint8_t[32]')
+
+    lib.crypto_hidden_key_pair(hidden_pk, sk, seed)
+#    return bytes(hidden_pk), PrivateKey(bytes(sk))
+    return bytes(hidden_pk), bytes(sk)

--- a/src/monocypher/bindings/crypto_hidden.py
+++ b/src/monocypher/bindings/crypto_hidden.py
@@ -1,13 +1,14 @@
 from monocypher.utils import ensure_length
 from monocypher._monocypher import lib, ffi
 
+
 def crypto_curve_to_hidden(your_pk, tweak):
     ensure_length('your_pk', your_pk, 32)
 
     curve = ffi.from_buffer('uint8_t[32]', your_pk)
     hidden = ffi.new('uint8_t[32]')
 
-    if lib.crypto_curve_to_hidden(hidden, curve, tweak):
+    if lib.crypto_curve_to_hidden(hidden, curve, tweak): # pragma: no cover
         return None # unsuitable for hiding
     return bytes(hidden)
 

--- a/tests/test_hidden.py
+++ b/tests/test_hidden.py
@@ -1,0 +1,53 @@
+from hypothesis import given
+from hypothesis.strategies import binary
+from pytest import raises
+from monocypher.utils import random
+from monocypher.public import PublicKey, PrivateKey, Box
+from monocypher.bindings.crypto_hidden import crypto_curve_to_hidden, crypto_hidden_to_curve, crypto_hidden_key_pair
+
+SEED = binary(min_size=31,max_size=33)
+BLIND = binary(min_size=32, max_size=32)
+
+@given(SEED, BLIND)
+def test_gen_unhide_hide(seed, blind):
+    try:
+        hidden_pk, sk = crypto_hidden_key_pair(seed)
+    except TypeError as e:
+        assert str(e) == 'your_secret_seed must have length 32'
+        return
+    assert len(seed) == 32
+
+    unhidden_pk = crypto_hidden_to_curve(hidden_pk)
+
+    # we don't know the order used to compute the unhidden pk, so to test
+    # that it's compatible we compute
+    #   DH(blind_sk, pk)
+    #   DH(blind_sk, unhidden_pk)
+    blind_sk = PrivateKey(blind)
+    box_direct   = Box(blind_sk, PrivateKey(sk).public_key)
+    box_unhidden = Box(blind_sk, PublicKey(unhidden_pk))
+    assert box_direct.shared_key == box_unhidden.shared_key
+
+    tweak = (hidden_pk[31] & 0b11000000)
+    # we don't know which representative we got, the lower bit of the tweak
+    # selects the negative/positive (can't remember which is which).
+    # we compute both and check which one matches:
+    rehidden_pk0 = crypto_curve_to_hidden(unhidden_pk, tweak)
+    rehidden_pk1 = crypto_curve_to_hidden(unhidden_pk, tweak|1)
+    if hidden_pk == rehidden_pk0:
+        rehidden_pk = rehidden_pk0
+    else:
+        assert hidden_pk == rehidden_pk1
+        rehidden_pk = rehidden_pk1
+
+
+def test_vector1():
+    '''Generated manually with a C program using libMonocypher'''
+    seed = b'\xec\x9b\x04\xcf\x0b\x43\xf5\xd9\x05\x20\x8d\xbc\xc8\x10\xe8\x59\x22\xa2\xaa\x7b\x73\xf6\xcf\x54\x64\x41\x41\x3d\xfc\xbe\x45\xbd'
+    hidden_to_curve = b'\xc0\xcb\x33\x08\xef\x16\x76\x7b\x35\xf5\x73\xf1\x53\x39\xbb\x55\xaa\xe9\x89\xb5\x01\x1e\x58\x55\xdd\x08\xde\x0f\x16\xdf\xfa\x62'
+    curve_to_hidden = b'\xec\x9b\x04\xcf\x0b\x43\xf5\xd9\x05\x20\x8d\xbc\xc8\x10\xe8\x59\x22\xa2\xaa\x7b\x73\xf6\xcf\x54\x64\x41\x41\x3d\xfc\xbe\x45\x3d'
+    tweak = 6
+    curve = crypto_hidden_to_curve(seed)
+    assert curve == hidden_to_curve
+    recovered = crypto_curve_to_hidden(curve, 6)
+    assert recovered == curve_to_hidden

--- a/tests/test_hidden.py
+++ b/tests/test_hidden.py
@@ -28,6 +28,15 @@ def test_gen_unhide_hide(seed, blind):
     box_unhidden = Box(blind_sk, PublicKey(unhidden_pk))
     assert box_direct.shared_key == box_unhidden.shared_key
 
+    # Elligator2 maps a point to a 254-bit representative indistinguishable
+    # from uniformly random bits (with a negliby small bias), but the upper
+    # two bits of our 256-bit values are always 0, so the 256-bit values the
+    # user operates on are statistically recognizable (by looking at these
+    # two bits). To work around that problem, the Monocypher library copies
+    # the two upper bits of the 8-bit "tweak" into bits 254 and 255.
+    # For the purpose of this test we need to reconstruct the original
+    # "tweak" argument by carving these two padding bits out from the 256-bit
+    # value:
     tweak = (hidden_pk[31] & 0b11000000)
     # we don't know which representative we got, the lower bit of the tweak
     # selects the negative/positive (can't remember which is which).


### PR DESCRIPTION
This PR exposes the low-level Elligator 2 functions `crypto_hidden_key_pair`, `crypto_hidden_to_curve`, `crypto_curve_to_hidden`.

There's no high-level wrapper, and no `.rst` documentation, but I think it's still useful. :-)

I also loosened the constraint on the `hypothesis` library in `requirements.txt` to avoid forcing a downgrade.

edit: ping @eugene-eeo 